### PR TITLE
docs: Specify `branch` in tree sitter parser config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
 parser_config.markdoc = {
   install_info = {
     url = "https://github.com/markdoc-extra/tree-sitter-markdoc",
-    files = { "src/parser.c" }
+    files = { "src/parser.c" },
+    branch = "main",
    },
   filetype = "markdoc",
 }


### PR DESCRIPTION
Tree sitter was failing to install the parser because it temporarily clones the repo to a directory suffixed with `-main`, and then moves it elsewhere. However, the move command was expecting a folder suffixed with `-master`. The fix is to explicitly specify a default branch of `main` in the parse config.